### PR TITLE
feat: add short description field to newsletter options

### DIFF
--- a/assets/public/scss/blocks/newsletter-form.scss
+++ b/assets/public/scss/blocks/newsletter-form.scss
@@ -28,7 +28,7 @@
         input[type=email] {
             @include body-m;
             width: 100%;
-            margin-bottom: 1rem;
+            margin-bottom: 2rem;
             padding: 0.88rem 1.5rem 0.81rem 1.5rem;
             color: rgba(39, 39, 39, 0.60);
             border: 1px solid rgba(39, 39, 39, 0.20);
@@ -47,7 +47,15 @@
         .input-checkbox {
             position: relative;
             display: block;
-            margin-bottom: 1rem;
+            margin-bottom: 0.375rem;
+
+            > .description {
+                display: block;
+                margin-top: 0.25rem;
+                padding-left: 1.625rem;
+                color: rgba(39, 39, 39, 0.6);
+                font-size: 0.875em;
+            }
 
             input {
                 position: absolute;
@@ -71,6 +79,17 @@
                         border: 0.125rem solid #7b7a79;
                         border-radius: 0.125rem;
                         background-color: transparent;
+                    }
+                }
+
+                &[name^="custom_fields"] {
+                    + .label:before {
+                        position: relative;
+                        top: 5px;
+                    }
+
+                    &:checked + .label:after {
+                        top: calc(-0.0625rem + 5px);
                     }
                 }
 

--- a/functions.php
+++ b/functions.php
@@ -16,6 +16,7 @@ require __DIR__ . '/src/legacy/functions/UserSettings.php';
 require __DIR__ . '/src/legacy/functions/PagesExcludedFromIndex.php';
 require __DIR__ . '/src/legacy/functions/Htaccess.php';
 require __DIR__ . '/src/legacy/functions/ExternalJs.php';
+require __DIR__ . '/src/legacy/functions/NewsletterAdmin.php';
 
 $template = wp_get_theme()->get_template();
 $assets   = 'app/themes/' . $template . '/assets/';
@@ -320,4 +321,3 @@ add_filter('upload_mimes', function ($mime_types){
     $mime_types['epub'] = 'application/epub+zip';
     return $mime_types;
 });
-

--- a/src/app/src/BlockType/NewsletterFormBlockType.php
+++ b/src/app/src/BlockType/NewsletterFormBlockType.php
@@ -66,10 +66,15 @@ class NewsletterFormBlockType extends AbstractBlockType implements BlockTypeInte
                    <span class="label">' . strtoupper($attributes['primary']) . '</span>
                </label>')
             . (empty($optionals) ? '' : (implode('', array_map(
-                    fn(WP_Post $newsletter): string => '<label class="input-checkbox">
+                    function (WP_Post $newsletter): string {
+                        $shortDescription = trim((string)get_post_meta($newsletter->ID, 'short_description', true));
+
+                        return '<label class="input-checkbox">
                         <input type="checkbox" name="custom_fields[' . strtoupper($newsletter->post_name) . ']" value="ano">
-                        <span class="label">' . $newsletter->post_title . '</span>
-                    </label>',
+                        <span class="label">' . $newsletter->post_title . '</span>'
+                            . ('' === $shortDescription ? '' : '<span class="description">' . esc_html($shortDescription) . '</span>')
+                            . '</label>';
+                    },
                     $optionals,
                 )) . '<div class="border-top w-100 mt-3 pt-3"></div>')) .
             '<label class="input-checkbox">
@@ -77,7 +82,7 @@ class NewsletterFormBlockType extends AbstractBlockType implements BlockTypeInte
                  <span class="label">Súhlasím so spracúvaním osobných údajov</span>
              </label>
              <input type="hidden" name="updateExisting" value="1">
-             <button type="submit" name="submit" class="mt-2">Registrovať</button>
+             <button type="submit" name="submit" class="mt-4">Registrovať</button>
              </form>
         ');
     }

--- a/src/legacy/functions/NewsletterAdmin.php
+++ b/src/legacy/functions/NewsletterAdmin.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+add_action('edit_form_after_title', function ($post): void {
+    if (!($post instanceof WP_Post) || 'newsletter' !== $post->post_type) {
+        return;
+    }
+
+    $value = (string)get_post_meta($post->ID, 'short_description', true);
+
+    wp_nonce_field('newsletter_short_description', 'newsletter_short_description_nonce');
+
+    echo '<div style="margin-top:20px;">';
+    echo '<label for="newsletter_short_description" style="font-weight:600;display:block;margin-bottom:6px;">Stručný popis</label>';
+    echo '<input type="text" id="newsletter_short_description" name="newsletter_short_description" value="' . esc_attr($value) . '" style="width:100%;padding:8px;font-size:14px;" placeholder="Zobrazí sa pod názvom newslettera vo formulári">';
+    echo '</div>';
+});
+
+add_action('save_post_newsletter', function (int $postId): void {
+    if (!isset($_POST['newsletter_short_description_nonce'])
+        || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['newsletter_short_description_nonce'])), 'newsletter_short_description')) {
+        return;
+    }
+
+    if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+        return;
+    }
+
+    if (!current_user_can('edit_post', $postId)) {
+        return;
+    }
+
+    $value = isset($_POST['newsletter_short_description'])
+        ? sanitize_text_field(wp_unslash($_POST['newsletter_short_description']))
+        : '';
+
+    if ('' === $value) {
+        delete_post_meta($postId, 'short_description');
+    } else {
+        update_post_meta($postId, 'short_description', $value);
+    }
+});

--- a/src/legacy/post-metas.php
+++ b/src/legacy/post-metas.php
@@ -20,4 +20,12 @@ return [
             'single' => true,
         ],
     ],
+    'newsletter' => [
+        'short_description' => [
+            'auth_callback' => fn(): bool => current_user_can('edit_posts'),
+            'show_in_rest' => true,
+            'single' => true,
+            'type' => 'string',
+        ],
+    ],
 ];

--- a/src/legacy/post-types.php
+++ b/src/legacy/post-types.php
@@ -75,6 +75,6 @@ return [
         'rewrite' => ['slug' => 'newsletter'],
         'show_in_menu' => current_user_can('edit_others_posts'),
         'show_in_rest' => true,
-        'supports' => ['title', 'editor'],
+        'supports' => ['title'],
     ],
 ];


### PR DESCRIPTION
Adds a "short_description" meta field for the newsletter post type with a custom admin input, and renders the description under each optional newsletter checkbox in the subscription form.