### PR TITLE
feat: add MainWP Child plugin via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
         "symfony/validator": "^7.2",
         "symfony/html-sanitizer": "^7.2",
         "wpackagist-plugin/firebox": "dev-trunk",
-        "wpackagist-theme/twentytwentyfive": "1.3"
+        "wpackagist-theme/twentytwentyfive": "1.3",
+        "wpackagist-plugin/mainwp-child": "^6.1"
     },
     "require-dev": {
         "deployer/deployer": "^7.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54ae84472545f0aead7a6a2a9df7d356",
+    "content-hash": "d97746d487657065628ee94ae7f28e48",
     "packages": [
         {
             "name": "composer/installers",
@@ -6267,6 +6267,24 @@
             "time": "2025-10-23T11:00:23+00:00"
         },
         {
+            "name": "wpackagist-plugin/mainwp-child",
+            "version": "6.1.6",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/mainwp-child/",
+                "reference": "tags/6.1.6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/mainwp-child.6.1.6.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/mainwp-child/"
+        },
+        {
             "name": "wpackagist-plugin/w3-total-cache",
             "version": "2.8.14",
             "source": {
@@ -7569,8 +7587,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "wpackagist-plugin/firebox": 20,
-        "roave/security-advisories": 20
+        "roave/security-advisories": 20,
+        "wpackagist-plugin/firebox": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
@@ -7581,9 +7599,9 @@
         "ext-zend-opcache": "*",
         "ext-curl": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## What

Adds the [MainWP Child](https://wordpress.org/plugins/mainwp-child/) plugin so this site can be managed from the MainWP dashboard.

```
composer require wpackagist-plugin/mainwp-child   # resolved to 6.1.6
```

## Changes

- `composer.json` - added `wpackagist-plugin/mainwp-child: ^6.1` to `require`
- `composer.lock` - added the corresponding lock entry

Composer installs it to `web/app/plugins/mainwp-child/` via `composer/installers`, consistent with how the other plugins (`w3-total-cache`, `firebox`) are managed. Nothing outside Composer metadata is touched.

## Notes

- The lock also picked up cosmetic metadata changes (`plugin-api-version` 2.2.0 -> 2.9.0, `platform-dev` `[]` -> `{}`) because the lock was generated with an older Composer than the one used here. No effect on `composer install` in CI.
- Requires manual follow-up after deploy: activate the plugin and connect the site to the MainWP dashboard.

Generated with [Claude Code](https://claude.com/claude-code)